### PR TITLE
Allow elk-pi hat again.

### DIFF
--- a/recipes-core/raspberrypi-systemd-services/files/load-drivers
+++ b/recipes-core/raspberrypi-systemd-services/files/load-drivers
@@ -70,7 +70,7 @@ else
 fi
 
 # Probe the audio driver
-if [ $AUDIO_HAT = "hifi-berry-pro" ] || [ $AUDIO_HAT = "hifi-berry" ]; then
+if [ $AUDIO_HAT = "hifi-berry-pro" ] || [ $AUDIO_HAT = "hifi-berry" ] || [ $AUDIO_HAT = "elk-pi"]; then
     modprobe rpi-audio-evl audio_buffer_size=$AUDIO_BUFFER_SIZE audio_hat=$AUDIO_HAT audio_irq_affinity=$ISOLCPU
     # Give perms for userspace to access audio driver class
     chown -R mind:mind /sys/class/audio_evl


### PR DESCRIPTION
In order to get https://github.com/elk-audio/rpi-evl-audio-driver/pull/2 working, a simple change to not reject the elk-pi while starting up has to be applied.